### PR TITLE
Work with SSL reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ENV DEBIAN_FRONTEND noninteractive
 # Set ENV Variables externally Moodle_URL should be overridden.
 ENV MOODLE_URL http://127.0.0.1
 
+# Enable when using external SSL reverse proxy
+# Default: false
+ENV SSL_PROXY false
+
 ADD ./foreground.sh /etc/apache2/foreground.sh
 
 RUN apt-get update && \

--- a/moodle-config.php
+++ b/moodle-config.php
@@ -291,7 +291,9 @@ $CFG->admin = 'admin';
 //
 // Enable when using external SSL appliance for performance reasons.
 // Please note that site may be accessible via https: or https:, but not both!
-//      $CFG->sslproxy = true;
+if ( getenv('SSL_PROXY') == "true" ) {
+    $CFG->sslproxy = true;
+}
 //
 // This setting will cause the userdate() function not to fix %d in
 // date strings, and just let them show with a zero prefix.

--- a/moodle_variables.env
+++ b/moodle_variables.env
@@ -34,4 +34,4 @@ MOODLE_URL=http://localhost
 #MOODLE_URL=http://moodle.company.com
 
 # Enable when using external SSL reverse proxy
-SSL_PROXY=true
+SSL_PROXY=false

--- a/moodle_variables.env
+++ b/moodle_variables.env
@@ -32,3 +32,6 @@ DB_PORT_3306_TCP_ADDR=DB
 
 MOODLE_URL=http://localhost
 #MOODLE_URL=http://moodle.company.com
+
+# Enable when using external SSL reverse proxy
+SSL_PROXY=true


### PR DESCRIPTION
When i use a reverse proxy with ssl configured and point to container with moodle, it's create a loop ( ERR_TOO_MANY_REDIRECTS)

With this config I can do without problems. just type true on SSL_PROXY env. 