### PR TITLE
Version Push 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 		php-gd libapache2-mod-php postfix wget supervisor php-pgsql curl libcurl4 \
 		libcurl3-dev php-curl php-xmlrpc php-intl php-mysql git-core php-xml php-mbstring php-zip php-soap cron php-ldap && \
 	cd /tmp && \
-	git clone -b MOODLE_35_STABLE git://git.moodle.org/moodle.git --depth=1 && \
+	git clone -b MOODLE_36_STABLE git://git.moodle.org/moodle.git --depth=1 && \
 	mv /tmp/moodle/* /var/www/html/ && \
 	rm /var/www/html/index.html && \
 	chown -R www-data:www-data /var/www/html && \

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@ docker-moodle
 =============
 [![Build Status](https://dev.azure.com/jmhardison/Docker%20Moodle/_apis/build/status/jmhardison.docker-moodle?branchName=master)](https://dev.azure.com/jmhardison/Docker%20Moodle/_build/latest?definitionId=1) [![](https://images.microbadger.com/badges/image/jhardison/moodle.svg)](https://microbadger.com/images/jhardison/moodle "Get your own image badge on microbadger.com")
 
-A Dockerfile that installs and runs the latest Moodle 3.5 stable, with external MySQL Database.
+A Dockerfile that installs and runs the latest Moodle 3.6 stable, with external MySQL Database.
 
 `Note: DB Deployment uses version 5 of MySQL. MySQL:Latest is now v8.`
 
 Tags:
-* latest - 3.5 stable
+* latest - 3.6 stable
+* v3.6 - 3.6 stable
 * v3.5 - 3.5 stable
 * v3.4 - 3.4 stable
 * v3.3 - 3.3 stable
@@ -78,4 +79,3 @@ The following aren't handled, considered, or need work:
 
 This is a fork of [Jade Auer's](https://github.com/jda/docker-moodle) Dockerfile.
 This is a reductionist take on [sergiogomez](https://github.com/sergiogomez/)'s docker-moodle Dockerfile.
-


### PR DESCRIPTION
### Description

Push Moodle version to currently released 3.6

### Issues Resolved

- [Moodle 3.6 Release Notes](https://docs.moodle.org/dev/Moodle_3.6_release_notes)
- [Moodle 3.6.1 Release Notes](https://docs.moodle.org/dev/Moodle_3.6.1_release_notes)

### Check List

- [x] Image buildes successfully.
- [x] Image runs and service can be opened successfully.
- [x] All tests pass where applicable.
- [x] README.md updated where appropriate.
- [x] All commits have been signed.