### PR TITLE
rolled up to moodle 3.7 and ubuntu 19.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Docker-Moodle
 # Dockerfile for moodle instance. more dockerish version of https://github.com/sergiogomez/docker-moodle
 # Forked from Jade Auer's docker version. https://github.com/jda/docker-moodle
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 LABEL maintainer="Jonathan Hardison <jmh@jonathanhardison.com>"
 
 VOLUME ["/var/moodledata"]
 EXPOSE 80 443
-ADD moodle-config.php /var/www/html/config.php
+COPY moodle-config.php /var/www/html/config.php
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive
@@ -19,21 +19,21 @@ ENV MOODLE_URL http://127.0.0.1
 # Default: false
 ENV SSL_PROXY false
 
-ADD ./foreground.sh /etc/apache2/foreground.sh
+COPY ./foreground.sh /etc/apache2/foreground.sh
 
 RUN apt-get update && \
 	apt-get -y install mysql-client pwgen python-setuptools curl git unzip apache2 php \
 		php-gd libapache2-mod-php postfix wget supervisor php-pgsql curl libcurl4 \
 		libcurl3-dev php-curl php-xmlrpc php-intl php-mysql git-core php-xml php-mbstring php-zip php-soap cron php-ldap && \
 	cd /tmp && \
-	git clone -b MOODLE_36_STABLE git://git.moodle.org/moodle.git --depth=1 && \
+	git clone -b MOODLE_37_STABLE git://git.moodle.org/moodle.git --depth=1 && \
 	mv /tmp/moodle/* /var/www/html/ && \
 	rm /var/www/html/index.html && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/foreground.sh
 
 #cron
-ADD moodlecron /etc/cron.d/moodlecron
+COPY moodlecron /etc/cron.d/moodlecron
 RUN chmod 0644 /etc/cron.d/moodlecron
 
 # Enable SSL, moodle requires it

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@ docker-moodle
 =============
 [![Build Status](https://dev.azure.com/jmhardison/Docker%20Moodle/_apis/build/status/jmhardison.docker-moodle?branchName=master)](https://dev.azure.com/jmhardison/Docker%20Moodle/_build/latest?definitionId=1) [![](https://images.microbadger.com/badges/image/jhardison/moodle.svg)](https://microbadger.com/images/jhardison/moodle "Get your own image badge on microbadger.com")
 
-A Dockerfile that installs and runs the latest Moodle 3.6 stable, with external MySQL Database.
+A Dockerfile that installs and runs the latest Moodle 3.7 stable, with external MySQL Database.
 
 `Note: DB Deployment uses version 5 of MySQL. MySQL:Latest is now v8.`
 
 Tags:
-* latest - 3.6 stable
+* latest - 3.7 stable
+* v3.7 - 3.7 stable
 * v3.6 - 3.6 stable
 * v3.5 - 3.5 stable
 * v3.4 - 3.4 stable


### PR DESCRIPTION
### Description

This is a rollup to Moodle version 3.7 and a base layer rollup to Ubuntu 19.04.

### Issues Resolved

https://docs.moodle.org/dev/Moodle_3.7_release_notes

### Check List

- [x] Image builds successfully.
- [ x] Image runs and service can be opened successfully.
- [ x] All tests pass where applicable.
- [ x] README.md updated where appropriate.
- [ ] All commits have been signed.